### PR TITLE
GOL-191 Use urlencode from future

### DIFF
--- a/common/templatetags/common_tags.py
+++ b/common/templatetags/common_tags.py
@@ -8,7 +8,8 @@ Credits:
  * code for `set` tag is based on http://djangosnippets.org/snippets/215/
 """
 from cgi import parse_qsl
-from urllib import urlencode
+
+from future.moves.urllib.parse import urlencode
 
 from django import template
 from django.utils.encoding import smart_str

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ from setuptools import setup, find_packages
 setup(
     name = 'django-common',
     description = 'A number of useful django shortcuts and helpers',
-    version = '0.1.52',
+    version = '0.1.53',
     author = 'Grigoriy Petukhov',
     author_email = 'lorien@lorien.name',
     url = 'http://bitbucket.org/lorien/django-common/',
-    install_requires=['six'],
+    install_requires=['six', 'future'],
     packages = find_packages(),
     include_package_data = True,
 


### PR DESCRIPTION
Fixing `cannot import name 'urlencode' from 'urllib'` in Python 3.